### PR TITLE
#26 fix: handling zero value x/y coordinates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 dougrich
+Copyright (c) 2020 dougrich
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/components/typography.js
+++ b/components/typography.js
@@ -41,7 +41,7 @@ const Typography = {
   ),
   Copyright: () => (
     <div className={css.copyright}>
-      Made by Douglas Richardson © 2019.<br/>Fonts available through the <a href="https://creativecommons.org/share-your-work/public-domain/cc0/" target="_blank">Creative Commons CC0 License</a>.<br/>Code available through the <a href="https://opensource.org/licenses/MIT" target="_blank">MIT License</a>.
+      Made by Douglas Richardson © 2020.<br/>Fonts available through the <a href="https://creativecommons.org/share-your-work/public-domain/cc0/" target="_blank">Creative Commons CC0 License</a>.<br/>Code available through the <a href="https://opensource.org/licenses/MIT" target="_blank">MIT License</a>.
     </div>
   ),
   Small: ({ children }) => (

--- a/state/reducers/fonts/parsePath.js
+++ b/state/reducers/fonts/parsePath.js
@@ -376,8 +376,8 @@ class PathParser {
     }
 
     for (const cmd of commands) {
-      if (cmd.x) cmd.x = cmd.x * scale
-      if (cmd.y) cmd.y = (unitsPerEm - cmd.y * scale) + descender
+      if (cmd.x != null) cmd.x = cmd.x * scale
+      if (cmd.y != null) cmd.y = (unitsPerEm - cmd.y * scale) + descender
     }
 
     warnings = warnings.filter((x, i, arr) => arr.indexOf(x) === i)

--- a/state/reducers/fonts/parsePath.spec.js
+++ b/state/reducers/fonts/parsePath.spec.js
@@ -4,17 +4,19 @@ const path = require('path')
 
 const PathParser = require('./parsePath')
 
-function expectPathMatch(actual, expected) {
-  expect(actual.length).to.eql(expected.length, `Expected paths to have the same number of elements`)
-  for (const i in expected) {
+function expectPathMatch(actualPoints, expectedPoints) {
+  expect(actualPoints.length).to.eql(expectedPoints.length, `Expected paths to have the same number of elements`)
+  for (const i in expectedPoints) {
+    const expected = expectedPoints[i]
+    const actual = actualPoints[i]
     expect(actual.type).to.eql(expected.type, `Expected ${i} type to match`)
-    if (expected.x != null) {
+    if (expected.x !== undefined) {
       expect(actual.x).to.be.within(expected.x - 0.1, expected.x + 0.1, `Expected ${i}.x to be +/- 0.1`)
     } else {
       expect(actual.x).to.be.undefined
     }
 
-    if (expected.y != null) {
+    if (expected.y !== undefined) {
       expect(actual.y).to.be.within(expected.y - 0.1, expected.y + 0.1, `Expected ${i}.y to be +/- 0.1`)
     } else {
       expect(actual.y).to.be.undefined
@@ -368,6 +370,18 @@ describe('PathParser#parse', () => {
       { type: 'L', x: 999.999730717868, y: -200.00026928195075 },
       { type: 'L', x: 199.99973071804925, y: -199.99973071786803 },
       { type: 'L', x: 200.00026928213208, y: 600.0002692819508 },
+      { type: 'Z' }
+    ])
+  })
+
+  it('handles exactly zero value xy coordinates correctly', () => {
+    const { commands, warnings } = parse('zero-xy.svg')
+    expect(warnings).to.be.empty
+    expectPathMatch(commands, [
+      { type: 'M', x: 0, y: 800 },
+      { type: 'L', x: 100, y: 800 },
+      { type: 'L', x: 100, y: -200 },
+      { type: 'L', x: 0, y: -200 },
       { type: 'Z' }
     ])
   })

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -4,7 +4,7 @@
    xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
     <url>
         <loc>https://dougrich.github.io/conscripter</loc>
-        <lastmod>2019-04-11</lastmod>
+        <lastmod>2020-04-02</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>

--- a/tests/parsePath/zero-xy.svg
+++ b/tests/parsePath/zero-xy.svg
@@ -1,0 +1,5 @@
+<svg version="1.1" viewBox="0.0 0.0 100.0 100.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
+<g>
+<path fill="#000000" d="M0 0L10 0L10 100L0 100Z" fill-rule="evenodd"/>
+</g>
+</svg>


### PR DESCRIPTION
Fixes #26 issues - all these were caused by weird handling of _exactly_ zero coordinates that popped up because of JS treating 0 as falsey.